### PR TITLE
Remove "impossible case"

### DIFF
--- a/spec_parser/mkdocs.py
+++ b/spec_parser/mkdocs.py
@@ -74,17 +74,18 @@ def gen_mkdocs(model, outdir, cfg):
         files[nsn].extend(_gen_filelist(nsn, ns.vocabularies, "Vocabularies"))
         files[nsn].extend(_gen_filelist(nsn, ns.individuals, "Individuals"))
         files[nsn].extend(_gen_filelist(nsn, ns.datatypes, "Datatypes"))
-                 
+
     filelines = []
-    filelines.append('- model:')
+    filelines.append("- model:")
     # hardwired order of namespaces
     for nsname in ["Core", "Software", "Security",
-               "Licensing", "SimpleLicensing", "ExpandedLicensing", 
+               "Licensing", "SimpleLicensing", "ExpandedLicensing",
                "Dataset", "AI", "Build", "Lite", "Extension"]:
         filelines.extend(files[nsname])
 
     fn = p / "mkdocs-files.yml"
     fn.write_text("\n".join(filelines))
+
 
 def class_link(name):
     if name.startswith("/"):

--- a/spec_parser/model.py
+++ b/spec_parser/model.py
@@ -245,9 +245,9 @@ class Class:
             if "maxCount" not in self.properties[prop]:
                 self.properties[prop]["maxCount"] = "*"
         for prop in self.restrictions:
+            self.restrictions[prop]["fqname"] = prop
             _, other_ns, class_name, _ = prop.split("/")
             desc_same_as_superclass = f"Same as [/{other_ns}/{class_name}](../../{other_ns}/Classes/{class_name}.md)"
-            self.restrictions[prop]["fqname"] = prop if prop.startswith("/") else f"/{ns.name}/{prop}"
             if "minCount" not in self.restrictions[prop]:
                 self.restrictions[prop]["minCount"] = desc_same_as_superclass
             if "maxCount" not in self.restrictions[prop]:


### PR DESCRIPTION
Property name in External properties restrictions section should always starts with /

There's no code to fix the situation if it's not, so no need to check for now.